### PR TITLE
#287 Handle cancel exception from queue take

### DIFF
--- a/src/NLog.Targets.Syslog/AsyncLogger.cs
+++ b/src/NLog.Targets.Syslog/AsyncLogger.cs
@@ -107,6 +107,11 @@ namespace NLog.Targets.Syslog
 
                 return tcs.Task;
             }
+            catch (OperationCanceledException)
+            {
+                tcs.SetCanceled();
+                return tcs.Task;
+            }
             catch (Exception exception)
             {
                 tcs.SetException(exception);


### PR DESCRIPTION
Closes #287

The queue.take can throw an OperationCanceledException when token is canceled. This should be handled so the TaskCompletionSource (tcs) SetCanceled is called instead of the current SetException. The SetException results in an UnobservedTaskException being raised later when the task is garbage collected. 